### PR TITLE
Improve docker documentation

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -25,3 +25,5 @@ docker:
         url: /_pages/topics/docker/networks/
       - title: 'Volumes'
         url: /_pages/topics/docker/volumes/
+      - title: 'FAQ'
+        url: /_pages/topics/docker/faq/

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -9,8 +9,14 @@ docker:
     children:
       - title: 'Usage and configuration'
         url: /_pages/topics/docker/
+  - title: 'Installation'
+    children:
       - title: 'Installation'
         url: /_pages/topics/docker/install/
+      - title: 'Enabling necessary Windows features'
+        url: /_pages/topics/docker/docker-windows-enabled-features
+  - title: 'Usage'
+    children:
       - title: 'Container Images'
         url: /_pages/topics/docker/images/
       - title: 'Containers'

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -3,3 +3,19 @@ main:
     url: /tags/
   - title: "Rólunk"
     url: /about/
+
+docker:
+  - title: "Docker"
+    children:
+      - title: 'Usage and configuration'
+        url: /_pages/topics/docker/
+      - title: 'Installation'
+        url: /_pages/topics/docker/install/
+      - title: 'Container Images'
+        url: /_pages/topics/docker/images/
+      - title: 'Containers'
+        url: /_pages/topics/docker/containers/
+      - title: 'Networks'
+        url: /_pages/topics/docker/networks/
+      - title: 'Volumes'
+        url: /_pages/topics/docker/volumes/

--- a/_pages/topics/docker/containers.md
+++ b/_pages/topics/docker/containers.md
@@ -4,9 +4,9 @@ sidebar:
     nav: "docker"
 ---
 
-Containers are the objects that run your software, isolated from the system and other containers, and store its mutable state.  
+Containers are the objects that run your software - isolated from the system and other containers - and store its mutable state.  
 They also store a reference to the container image from which they were instantiated,
-and all of the files and container configuration that were changed compared to the image.
+and all of the files and container configuration that were changed compared to this image.
 
 ## Basic Usage
 
@@ -23,8 +23,10 @@ In this case it can be stopped by pressing `Ctrl+C`. If you press it twice, Dock
 
 Be aware that by default containers are not deleted when stopped.  
 That means, if you always create a new container this way, it might slowly fill up your storage space.
+{: .notice}
 
-Below are some useful options. You don't need to memorize them, you can always come back when you need one, but it is recommended to at least skim through what is available.
+Below are some useful options. You don't need to memorize them,
+you can always come back when you need one, but it is recommended to at least skim through to be aware of what is available.
 
 |Option|Meaning|  
 |---|---|
@@ -42,7 +44,8 @@ Below are some useful options. You don't need to memorize them, you can always c
 
 ### Listing existing containers
 
-If you have already created containers, you may list them with the `docker container ls --all` command. The `--all` option makes sure that containers that are currently not running are also listed.
+If you have already created containers, you may list them with the `docker container ls --all` command.
+The `--all` option makes sure that containers that are currently not running are also included.
 
 ```
 $ sudo docker container ls --all
@@ -79,7 +82,9 @@ If you don't need a container anymore, you can delete it with the `docker contai
 For deleting a running container, you will need to use the `--force` option.  
 For deleting all anonymous volumes of a container, you will need to use the `--volumes` option. This is recommended to use when you really don't need the container anymore.
 
-Deletions are not reversible, take extreme care when deleting containers or volumes.
+Deletions are not reversible.  
+Take extreme care when deleting containers or volumes.
+{: .notice--danger}
 
 ### The container upgrade procedure
 
@@ -88,10 +93,13 @@ Instead of updating the software in the container with the package manager or wi
 
 As all important data is stored on volumes, nothing of value should be lost.
 
+For persisting configuration values, you can use Docker Compose, but it is also possible to view the current configuration of a container.
+{: .notice--info}
+
 ## Advanced usage
 
 All of the container management commands are subcommands of the `docker container` command.  
-They can be listed by running `docker container --help`, but below I have made a list of the more useful ones:
+They can be listed by running `docker container --help`, but below is a list of the more useful ones:
 
 |Subcommand|Meaning|
 |---|---|
@@ -104,5 +112,5 @@ They can be listed by running `docker container --help`, but below I have made a
 |rename|Rename the container|
 |commit|Create a new container image from the current state of the container|
 
-All of the subcommands will print their detailed usage and available options when run with the `--help` option.
+All of the subcommands will print their detailed usage and available options when ran with the `--help` option.
 All of them are also documented in detail [here](https://docs.docker.com/engine/reference/commandline/container/).

--- a/_pages/topics/docker/containers.md
+++ b/_pages/topics/docker/containers.md
@@ -1,6 +1,8 @@
 ---
 title: Docker Containers
 tags: Docker
+sidebar:
+    nav: "docker"
 ---
 
 Containers are the objects that run your software, isolated from the system and other containers, and store its mutable state.  

--- a/_pages/topics/docker/containers.md
+++ b/_pages/topics/docker/containers.md
@@ -1,6 +1,5 @@
 ---
 title: Docker Containers
-tags: Docker
 sidebar:
     nav: "docker"
 ---

--- a/_pages/topics/docker/docker-windows-enabled-features.md
+++ b/_pages/topics/docker/docker-windows-enabled-features.md
@@ -1,6 +1,8 @@
 ---
 title: Enabling Windows features required by Docker
 tags: Docker
+sidebar:
+    nav: "docker"
 ---
 
 Docker, when ran on Windows, requires enabling the features corresponding to the virtualization backend to be used.  

--- a/_pages/topics/docker/docker-windows-enabled-features.md
+++ b/_pages/topics/docker/docker-windows-enabled-features.md
@@ -1,6 +1,5 @@
 ---
 title: Enabling Windows features required by Docker
-tags: Docker
 sidebar:
     nav: "docker"
 ---

--- a/_pages/topics/docker/faq.md
+++ b/_pages/topics/docker/faq.md
@@ -1,0 +1,68 @@
+---
+title: Frequently Asked Questions
+sidebar:
+    nav: "docker"
+---
+
+## How can I recognize the name of a container image?
+
+Your teammates have said you need to run a container. You remember its name, but you are not sure about how was it written exactly.    
+
+Container image names tipically look like one of these:
+- `gitea/gitea`
+- `gitea/gitea:1.19`
+
+These are also commonly found on websites of Container Registries, like Docker Hub, but also in your software's (e.g. Gitea) own documentation.
+
+## I have the name of a container image, how can I run it?
+
+Your team has said you need to start up a new container thats called this way: `gitea/gitea:1.19`.   
+You can run it with the following command:
+```
+sudo docker run gitea/gitea:1.19
+```
+
+The container will start up, and it will hold your command prompt until it has finished running.  
+If you want to stop it, you can press `Ctrl + C`. You may need to wait a couple of seconds until it gracefully stops.
+
+This command will assume a lot of default settings. If you need to customize anything, you can use options. You can read more about them in the [Containers](containers.md) tutorial.  
+But it is worth mentioning, that it is common to use the `-d`  option, which makes the container run in the background.
+
+## I have a Docker Compose file, how do I start it?
+
+For more complex software it is common to use Docker Compose files,
+which essentially contain everything (configurationwise) about how should the container be run, and what other things are needed for it to function properly.  
+These files are commonly distributed along with the source code of the software.
+
+Docker Compose files are called either of these ways:
+- docker-compose.yml
+- docker-compose.yaml
+
+When you see one, you can make use of it by changing to the directory in your terminal where this file is located, and then by running the following command:
+```
+sudo docker compose up
+```
+
+The command will automatically find the file with the above name, and create all Docker resources and start the containers as specified inside of it.
+
+It is worth mentioning, that similarly to the `docker run` command, it is common to use the `-d`  option, which makes the stack run in the background.
+
+## I have a `Dockerfile`, how do I build the container using it?
+
+Files whose name is either `Dockerfile`, or start with `Dockerfile.`, contain the instructions to make a new container image.  
+These files are commonly distributed along with the source code of the software.
+
+First you need to install the Docker BuildKit. You can find more information about that [here](https://docs.docker.com/go/buildx/).
+
+Then you can start the build process with the following command:
+```
+sudo docker buildx build
+```
+
+Docker also has a `docker build` subcommand. Do not use that one, as it is deprecated, and it may not be able to build your container in the way you expect it.  
+{: .notice--warning}
+
+The Docker build system will look at the file named `Dockerfile`, and execute its instructions.  
+Files whose name start with `Dockerfile.` are not used automatically, but you can make use of them by specifiying their name with the `--file` option.
+
+When the build process has successfully finished, the resulting container image will be available for use by other Docker commands.

--- a/_pages/topics/docker/faq.md
+++ b/_pages/topics/docker/faq.md
@@ -14,6 +14,8 @@ Container image names tipically look like one of these:
 
 These are also commonly found on websites of Container Registries, like Docker Hub, but also in your software's (e.g. Gitea) own documentation.
 
+You can find more details [here](images.md#identification-of-images) on how to identify a container image name. 
+
 ## I have the name of a container image, how can I run it?
 
 Your team has said you need to start up a new container thats called this way: `gitea/gitea:1.19`.   

--- a/_pages/topics/docker/images.md
+++ b/_pages/topics/docker/images.md
@@ -1,6 +1,8 @@
 ---
 title: Container Images
 tags: Docker
+sidebar:
+    nav: "docker"
 ---
 
 Container images are immutable, snapshotted states of a container.

--- a/_pages/topics/docker/images.md
+++ b/_pages/topics/docker/images.md
@@ -32,8 +32,10 @@ Status: Downloaded newer image for gitea/gitea:latest
 docker.io/gitea/gitea:latest
 ```
 
-With this command images are downloaded from a container registry.  
-When no container registry is given at the beginning of the name, it is downloaded from Docker Hub.
+With this command images are downloaded from a container registry.
+
+When no container registry is given at the beginning of the name, Docker Hub is assumed.
+{: .notice--info}
 
 ### Listing downloaded images
 
@@ -74,15 +76,24 @@ Their name is a human readable name, usually the name of a software. They might 
 - When obtained from a container registry, the name will also include the user or organization that publishes it (e.g. `gitea/gitea`).  
 - Names might also contain the container registry from where they were downloaded (e.g. `lscr.io/linuxserver/wireguard`).
 
+In this last example, the image is searched for and downloaded from the lscr.io container registry.
+{: .notice--info}
+
 Tags are used to differentiate between different flavors of the image, based on version number, release type (release, development, nightly), base linux distribution, or others.  
-When no tags are specified, `latest` is used, which frequently points to the last uploaded container image, which might be a nightly release when you just wanted the latest stable one, so its use is generally discouraged.  
-A specific NAME:TAG pair might still have further image variants when different images are built for different "platforms" (CPU architectures).
+When no tags are specified, `latest` is used.
+
+`latest` frequently points to the last uploaded container image, which might be a nightly release when you just wanted the latest stable one, so its use is generally discouraged.
+{: .notice--warning}
+
+A specific `NAME:TAG` pair might still have further image variants when different images are built for different "platforms" (CPU architectures).
+{: .notice}
 
 The digest is the checksum (usually SHA256) of (the top layer of) a container image.
+{: .notice}
 
 ### Additional ways for obtaining images
 
-#### Manually loading images in the OCI image format
+#### Manually loading images of the OCI image format
 
 Sometimes the image you want to use was built on a different system, and you may not want to upload it to a container registry.  
 In that case, you can export and import it in a tar file:
@@ -91,7 +102,8 @@ docker image save --output gitea_1.18.5.tar local/gitea:1.18.5
 docker image load --input gitea_1.18.5.tar
 ```
 
-Important: do not use the `docker export` and `docker import` commands for this task! They only manage the filesystem of the image, they ignore any metadata stored in it, such as the file to be ran on startup.
+Do not mix up `docker export` and `docker import` with these commands! They only manage the **filesystem** of the image, they ignore any **configuration** stored in it, such as the file to be ran on startup.
+{: .notice--warning}
 
 #### Uploading to a container registry
 
@@ -100,6 +112,6 @@ Then you can use `docker image push <image>` to start the upload process.
 
 ### Creating images
 
-You can also create container images, and for that you have 2 options:
+You can also create your own container images. There are 2 ways for that:
 - with the build process using `Dockerfile`s (the proper way)
 - by snapshotting a container, thus preserving its current state in a new immutable layer

--- a/_pages/topics/docker/images.md
+++ b/_pages/topics/docker/images.md
@@ -1,6 +1,5 @@
 ---
 title: Container Images
-tags: Docker
 sidebar:
     nav: "docker"
 ---

--- a/_pages/topics/docker/index.md
+++ b/_pages/topics/docker/index.md
@@ -159,9 +159,9 @@ It also supports management of other containerization environments, like Podman,
 
 Some highlights:
 
-|Container list|Image list|Container details|
+|Container list|Image list| Container details |
 |---|---|---|
-|![Container list menu of Portainer.png](../../../assets/images/portainer-containers.png)|![Image list menu of Portainer](../../../assets/images/portainer-images.png)|![img.png](../../../assets/images/portainer-container-details.png)|
+|![Container list menu of Portainer](../../../assets/images/portainer-containers.png)|![Image list menu of Portainer](../../../assets/images/portainer-images.png)| ![Details of a running container in Portainer](../../../assets/images/portainer-container-details.png) |
 
 
 ## Similar software

--- a/_pages/topics/docker/index.md
+++ b/_pages/topics/docker/index.md
@@ -40,6 +40,10 @@ You can find information about installating Docker [on this page](install.md).
 
 ## Usage
 
+If you are in a hurry, and only use Docker because you were told to, head to the [FAQ](faq.md) for a very brief article about operations with which you can get going quikcly.  
+After reading it, it is still worthwhile to understand the basics. Continue with the rest of the article if you want to know more.  
+{: .notice}
+
 When using Docker, frequently you will deal with containers, and the resources used by them.  
 When you use Docker Engine (but should apply to Docker Desktop too), you'll be able to manage these through the `docker` command and its subcommands.
 

--- a/_pages/topics/docker/index.md
+++ b/_pages/topics/docker/index.md
@@ -1,6 +1,8 @@
 ---
 title: _ Using and configuring Docker
 tags: Docker
+sidebar:
+    nav: "docker"
 ---
 
 In this document I'll briefly introduce Docker, and the common operations of it you may need to use.

--- a/_pages/topics/docker/index.md
+++ b/_pages/topics/docker/index.md
@@ -8,16 +8,19 @@ sidebar:
 In this document I'll briefly introduce Docker, and the common operations of it you may need to use.
 
 If you are a student at SZTE, and doing the "Rendszerfejlesztés 2" course in the spring semester of 2023, you are welcome at [the course forum](https://www.coosp.etr.u-szeged.hu/Scene-718272/Forum-2760968) if you need help, or if you have feedback.  
-If you have feedback, I believe you can also open an issue at the [Cave of Chrion](https://github.com/ChironSZTE/cave-of-chiron) Github repository, and tag it as a bug.
+In the latter case, I believe you can also open an issue at the [Cave of Chrion](https://github.com/ChironSZTE/cave-of-chiron) Github repository, and tag it as a bug.
+{: .notice}
 
 ## Introduction
 
 Docker is a popular **containerization platform**.  
-The point of containerization platforms is that as a developer/project maintainer,
-you can package your software for a system with all the dependencies that it needs to properly run,
+The point of containerization platforms is that as a developer/project maintainer
+you can package your software for a system with all the dependencies it needs to properly run,
 instead of relying on the user (system administrator) to find the _correct_ versions of the _correct_ packages.
-It is usually also easier for the user. You will see why.  
+It is usually also easier for the user, because the software (-stack) has been pre-configured.  
+
 However it is also important to mention that this is not a suitable solution for all compatibility problems. Such tools are not for end users.
+{: .notice--warning}
 
 With Docker, any software you run is packaged into a "container".  
 A container is like a regularly installed operating system, but most usually one based on Linux, and without a graphical environment. However it's important to note that these are not limitations, but how things are usually done, for practical reasons.
@@ -29,7 +32,7 @@ If you have used virtual machines, the concept might seem familiar, but there ar
     This means lower memory usage, and easier resource sharing (filesystems, network, ...), but also sharing of kernel **vulnerabilities**. Keep your Host OS (and Docker) up to date if you run containerized services published to any public network! (e.g. internet, school network)
 
 Containers are usually distributed as container images.  
-If someone has made one for the software you want to use, you can download and use it, but you can also make one yourself. It's quite easy, you'll see. 
+If someone has made one for the software you want to use, you can download and use it, but you can also make one yourself. 
 
 ## Installation
 
@@ -41,12 +44,15 @@ When using Docker, frequently you will deal with containers, and the resources u
 When you use Docker Engine (but should apply to Docker Desktop too), you'll be able to manage these through the `docker` command and its subcommands.
 
 When giving examples to commands, I may use `[foo]` and `<bar>`. These mean that `foo` is an optional parameter, but `bar` is mandatory.
+{: .notice--info}
 
 Almost all docker commands have options for modifying their behavior,
 but for the sake of simplicity, I may not list every one of them.
 The full list of subcommands and options can be obtained with using the `--help` option for any command.
+{: .notice--info}
 
 You may have to run the `docker` command with administrator privileges.
+{: .notice--info}
 
 ### Containers
 
@@ -72,7 +78,7 @@ You can read about them [on this page](volumes.md).
 
 ## Configuration
 
-Dockers configuration can be divided into 3 categories:
+Docker's configuration can be divided into 3 categories:
 - configuration of individual docker resources
 - docker daemon configuration
 - docker CLI configuration
@@ -82,7 +88,7 @@ The configuration of individual docker resources were covered in pages reference
 ### Docker daemon configuration
 
 The Docker daemon is the background process that controls the containers and all other Docker resources.  
-It is usually [automatically started](https://docs.docker.com/config/daemon/start/) by the system, and runs until it is shut down.
+It is usually [automatically started](https://docs.docker.com/config/daemon/start/) by the system, and runs until that is shut down.
 
 The primary way of its configuration is by editing the `daemon.json` file.  
 On Linux systems, it is located at `/etc/docker/daemon.json`.  
@@ -92,10 +98,15 @@ The available configuration options are documented [here](https://docs.docker.co
 
 Below are 2 configuration options, both of which override default configuration values of containers:
 
-|Option|Meaning|
-|---|---|
-|dns|Use a different set of DNS servers by default for every container. Useful if you run a DNS server on the Host, possibly as a Docker container, and you want Docker to be able to make use of locally defined domain names.|
-|log-driver|Use a different log storage driver by default for every container. The [default `json-file` driver](https://docs.docker.com/config/containers/logging/json-file/) might be inefficient (large files) for chatty containers, compared to the [`local` driver](https://docs.docker.com/config/containers/logging/local/).|
+|Option| Meaning                                                                                                                                                                                                                                                                                                             |
+|---|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|dns| Use a different set of default DNS servers for all containers. Useful if you run a DNS server on the Host, possibly as a Docker container, and you want Docker to be able to make use of locally defined domain names.                                                                                              |
+|log-driver| Use a different default log storage driver for all containers. The [default `json-file` driver](https://docs.docker.com/config/containers/logging/json-file/) might be inefficient (large files) for chatty containers, compared to the [`local` driver](https://docs.docker.com/config/containers/logging/local/). |
+
+Most daemon configuration options that allow overriding the defaults only apply to newly created containers.  
+This includes the examples above.  
+The reason is that if you do not define them for the container at creation, Docker will create them with the current defaults being saved explicitly.
+{: .notice--warning}
 
 ### Docker CLI configuration
 
@@ -116,13 +127,14 @@ Docker usually runs with root privileges, and it can also easily become part of 
 Fortunately it rarely introduces breaking changes, so updating it regularly shouldn't cause trouble.
 
 Deprecations and known breaking changes are published [on this page](https://docs.docker.com/engine/breaking_changes/).
+{: .notice--info}
 
 ### Freeing up unused resources
 
 Over time, you may accumulate resources that are no longer needed, but consume significant amounts of storage space.  
 The space consumed by these resources can be viewed by running the `docker system df` command:
 ```
-sudo docker system df
+$ sudo docker system df
 TYPE            TOTAL     ACTIVE    SIZE      RECLAIMABLE
 Images          11        11        1.453GB   406.9MB (28%)
 Containers      12        12        47.98MB   0B (0%)
@@ -134,11 +146,15 @@ You can go over the list of images, containers and volumes and delete what is no
 or you can ask Docker to delete what is not currently in use with the `docker system prune` command.
 You may refine its operation by using the options it provides.
 
+If you are not careful, `docker system prune` may delete resources that are not _currently_ in use, but still important.  
+Deletion is permanent.
+{: .notice--danger}
+
 ### Useful maintenance tools
 
 Docker is a popular containerization platform, and it has many 3rd party tools that may be used for its management.
 
-One such example is [Portainer](https://www.portainer.io/docker-swarm-container-management-platform-gui), that allows the management of your Docker resources through your web browser.  
+One such example is [Portainer](https://www.portainer.io/docker-swarm-container-management-platform-gui), which allows the management of your Docker resources through your web browser.  
 It also supports management of other containerization environments, like Podman, Kubernetes, and Nomad.
 
 Some highlights:

--- a/_pages/topics/docker/index.md
+++ b/_pages/topics/docker/index.md
@@ -1,5 +1,5 @@
 ---
-title: _ Using and configuring Docker
+title: Using and configuring Docker
 tags: Docker
 sidebar:
     nav: "docker"

--- a/_pages/topics/docker/install.md
+++ b/_pages/topics/docker/install.md
@@ -1,6 +1,5 @@
 ---
 title: Installation
-tags: Docker
 sidebar:
     nav: "docker"
 ---

--- a/_pages/topics/docker/install.md
+++ b/_pages/topics/docker/install.md
@@ -1,6 +1,8 @@
 ---
 title: Installation
 tags: Docker
+sidebar:
+    nav: "docker"
 ---
 
 Docker has 2 editions you can choose from when installing:

--- a/_pages/topics/docker/install.md
+++ b/_pages/topics/docker/install.md
@@ -6,31 +6,36 @@ sidebar:
 
 Docker has 2 editions you can choose from when installing:
 - [Docker Engine](https://docs.docker.com/engine/): The main part of Docker, manageable from the command line (recommended)
-- [Docker Desktop](https://docs.docker.com/desktop/): A GUI app for managing your Docker environment. Includes Docker Engine. It always runs the containers in a shared virtual machine.
+- [Docker Desktop](https://docs.docker.com/desktop/): A GUI app for managing your Docker environment. Includes Docker Engine.
 
 Docker Engine is recommended mainly because it is easier to use, _in my opinion_.  
 If you are a student at SZTE, and you are doing the "Rendszerfejlesztés 2" course in the spring semester of 2023, this is also what I can help with on [the course forum](https://www.coosp.etr.u-szeged.hu/Scene-718272/Forum-2760968).  
 If you use Docker Desktop, feel free to ask still, I (or someone else) may still be able to help.
 A lot of things are the same, but a fundamental change in how it works might make things a bit more difficult to manage.  
 Last but not least, Docker Engine is open source, while the additions of Docker Desktop are not.
+{: .notice}
 
-Docker Desktop is expected to also have higher resource usage, because of the use of a virtual machine.
+Docker Desktop is expected to also have higher resource usage, as it always runs the containers in a (shared) virtual machine.
+{: .notice}
 
 ## Linux
 
-On Linux based systems, you most probably want to install Docker from the package manager of your distribution, so that its packages get updated along with everything else it depends on.  
+On Linux based systems, it is best to install Docker from the package manager of your distribution, so that its packages get updated along with everything else it depends on.  
 This means the method depends on which distribution you use.
 
-Generally, it is best to read the official installation instructions ([Engine](https://docs.docker.com/engine/install/#server), [Desktop](https://docs.docker.com/desktop/install/linux-install/)), which also covers the system requirements.
+Generally, it is best to read the official installation instructions ([Engine](https://docs.docker.com/engine/install/#server), [Desktop](https://docs.docker.com/desktop/install/linux-install/)), which also cover the system requirements.
+
 For Docker Engine, start from the "Server" heading, as the "Desktop" heading redirects you to Docker Desktop.
+{: .notice--info}
 
 ## Windows
 
 On Windows, installation is done by installing [Docker Desktop](https://desktop.docker.com/win/main/amd64/Docker%20Desktop%20Installer.exe).  
 Docker Engine in itself is not available.
 
-It is recommended to read the [official installation instructions](https://docs.docker.com/desktop/install/windows-install/), which also covers the system requirements, but the above installer should handle everything by itself.
+It is recommended to read the [official installation instructions](https://docs.docker.com/desktop/install/windows-install/), which also cover the system requirements, but the above installer should handle everything by itself.
 
+Except one thing.  
 At installation, you will need to choose between using the WSL2 or the Hyper-V backend. [You can switch](https://docs.docker.com/desktop/faqs/windowsfaqs/#how-do-i-switch-between-windows-and-linux-containers) later on.  
 You may need to enable the WSL or Hyper-V features manually. If you still have access to the Control Panel, the steps to do so are described [here](docker-windows-enabled-features.md).
 
@@ -39,4 +44,4 @@ You may need to enable the WSL or Hyper-V features manually. If you still have a
 On Mac, installation is done by installing Docker Desktop ([x86]([](https://desktop.docker.com/mac/main/amd64/Docker.dmg)), [ARM (M1)](https://desktop.docker.com/mac/main/arm64/Docker.dmg)).  
 Docker Engine is not available in itself.
 
-It is recommended to read the [official installation instructions](https://docs.docker.com/desktop/install/mac-install/), which also covers the system requirements, but the above installer should handle everything by itself.
+It is recommended to read the [official installation instructions](https://docs.docker.com/desktop/install/mac-install/), which also cover the system requirements, but the above installer should handle everything by itself.

--- a/_pages/topics/docker/networks.md
+++ b/_pages/topics/docker/networks.md
@@ -1,6 +1,5 @@
 ---
 title: Docker Networks
-tags: Docker
 sidebar:
     nav: "docker"
 ---

--- a/_pages/topics/docker/networks.md
+++ b/_pages/topics/docker/networks.md
@@ -58,7 +58,7 @@ You can create a network with the `docker network create [options] <name>` comma
 docker network create my_network
 ```
 
-Useful options:
+Some useful options:
 
 |Option|Meaning|
 |---|---|

--- a/_pages/topics/docker/networks.md
+++ b/_pages/topics/docker/networks.md
@@ -1,6 +1,8 @@
 ---
 title: Docker Networks
 tags: Docker
+sidebar:
+    nav: "docker"
 ---
 
 Use of Docker networks are required for containers that need any kind of network access.  

--- a/_pages/topics/docker/volumes.md
+++ b/_pages/topics/docker/volumes.md
@@ -1,6 +1,5 @@
 ---
 title: Docker Volumes
-tags: Docker
 sidebar:
     nav: "docker"
 ---

--- a/_pages/topics/docker/volumes.md
+++ b/_pages/topics/docker/volumes.md
@@ -1,6 +1,8 @@
 ---
 title: Docker Volumes
 tags: Docker
+sidebar:
+    nav: "docker"
 ---
 
 Volumes are used for persistent file storage.  

--- a/_pages/topics/docker/volumes.md
+++ b/_pages/topics/docker/volumes.md
@@ -8,8 +8,10 @@ Volumes are used for persistent file storage.
 They allow you to store contents of directories outside of containers, and in turn independently of their state.
 This means that when you delete and recreate them (e.g. because you have updated them), files stored in volumes are kept.
 
-Volumes may also be used for sharing files between multiple containers,
-but this setup needs to be supported by the software running in both of them, otherwise you should expect data corruption to happen.
+Volumes may also be used for sharing files between multiple containers.
+
+This setup needs to be supported by the software running in both of them, otherwise you should expect data corruption to happen, purely out of them overwriting each other's work.
+{: .notice--warning}
 
 Based on the volume driver in use, the files may be stored at a network location,
 they may be encrypted, compressed, and other possibilities may become available with them.
@@ -20,14 +22,14 @@ The official documentation can be read [here](https://docs.docker.com/storage/vo
 
 The volumes are primarily differentiated based on how can you refer to them.
 
-Anonymous volumes are ones you cant refer to.  
-They are created when it is defined in the container image that certain directories should be stored in a volume, but the user did not set them up as a named volume.  
+**Anonymous volumes** are ones you cant refer to.  
+They are created when it is defined in the container image that certain directories should be stored in a volume, but the user did not set up a named volume for them.  
 Although they are not automatically removed along with the container, recreating the container will result in new anonymous volumes being used.  
 Their main purpose is simply to indicate which directories should be persisted when the user wants that, but still not interfere when the user intends to create a totally temporary container.
 
-Named volumes can be referred to by their names, and they will be reused as expected when the container is recreated.
+**Named volumes** can be referred to by their names, and they will be reused as expected when the container is recreated.
 
-Bind mounts are not actually volumes, but it is useful to mention them here.  
+There are also **bind mounts**, which are not actually volumes, but it is useful to mention them here.  
 They will persist your data like a named volume, but Docker will not list them among volumes.
 You define them by specifying a filesystem path instead of a volume name.
 
@@ -78,8 +80,10 @@ Below you will find a brief summary of the volume management commands, but you m
 
 ### Creating volumes
 
-Volumes can be created with the `docker volume create [options] [name]` command.  
+Volumes can be created with the `docker volume create [options] [name]` command.
+
 Omitting the `name` parameter will result in an anonymous volume being created.
+{: .notice--info}
 
 A specific driver and driver options can be set with the `--driver` and `--driver-opts` options.
 
@@ -87,12 +91,16 @@ A specific driver and driver options can be set with the `--driver` and `--drive
 Existing volumes can be listed with the `docker volume list` command.
 
 ### Changing volume settings
-Changing volume settings after creation is not possible without recreating it.  
-Be sure to backup all data in the volume before you deleting it!
+Changing volume settings after creation is not possible without recreating it.
+
+Be sure to backup all data in the volume before deleting it!
+{: .notice--warning}
 
 ### Deleting volumes
-You can delete a volume with the `docker volume remove <name>` command.  
-Warning! All data will be lost!
+You can delete a volume with the `docker volume remove <name>` command.
+
+Deletion is permanent! All data will be lost!
+{: .notice--danger}
 
 ## Volume drivers
 
@@ -121,10 +129,11 @@ The following parameters are used:
 On configuration of the `local` driver on Linux systems further explanation can be read [here](https://docs.docker.com/storage/volumes/#block-storage-devices).
 Note that the page mentions specifically "block devices", but actually it is relevant independently to the kind of filesystem you use.
 
-Note: it is possible to create named volumes that also work like a bind mount.  
+It is possible to create named volumes that also work like a bind mount.  
 To achieve that, you will need to use the `volume-opt=type=none` and `volume-opt=o=bind` parameters, and also specifiy a bind destination with `volume-opt=device=...`.  
 Example: `--mount "type=volume,source=myapp_data,destination=/var/lib/myapp,volume-opt=type=none,volume-opt=o=bind,volume-opt=device=/srv/myapp/data"`.  
 It is important to note that the volume data will not be stored at the bound location, it is merely _available_ at that path. Data is stored at the original location, and takes up storage space there, which is unchanged from conventional named volumes.
+{: .notice}
 
 ### 3rd party drivers
 


### PR DESCRIPTION
This PR resolves #44 .

## Improvements contained in this PR
### Fix tags, related articles
Until now, related articles were grouped by their tags, but this made it hard to find the main article.
Instead of tagging all Docker articles of mine with the Docker tag and ordering them with ugly special characters, now only the main article is tagged that way, and others are accessible from the sidebar of these articles.

||Tags|Related articles|
|-|-|-|
|**Before**|![image](https://user-images.githubusercontent.com/83356418/233603815-3b31bad3-7389-4e4b-afbd-9b59bfe2daf6.png)|![image](https://user-images.githubusercontent.com/83356418/233604389-6acae8f1-947a-40c5-affe-51c0929226f3.png)|
|**After**|![image](https://user-images.githubusercontent.com/83356418/233603152-61b5da9e-ac66-4b56-ae61-4ac9eefa2365.png)|![image](https://user-images.githubusercontent.com/83356418/233604250-bef54cea-ceb6-42f9-a006-8b05b2b1776a.png)|

### Hightlight warnings and tips

Warnings, tips and other good-to-know information is now visibly disctinct from the main content.

![image](https://user-images.githubusercontent.com/83356418/233606365-3dde6980-4b99-4352-ae21-dcdb85f9b31e.png)

![image](https://user-images.githubusercontent.com/83356418/233606150-f290d845-1068-4185-b43f-c1196b4c83d9.png)

### Brief summary on the essential operations

An FAQ article was added, which is being referred to from the Usage section of the main article.